### PR TITLE
skip cobertura measures of java files

### DIFF
--- a/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaReportParser.java
+++ b/sonar-groovy-plugin/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaReportParser.java
@@ -33,6 +33,7 @@ import org.sonar.api.measures.CoverageMeasuresBuilder;
 import org.sonar.api.measures.Measure;
 import org.sonar.api.utils.StaxParser;
 import org.sonar.api.utils.XmlParserException;
+import org.sonar.plugins.groovy.foundation.Groovy;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -121,7 +122,7 @@ public class CoberturaReportParser {
 
   private void handleFileMeasures(Map<String, ParsingResult> resultByFilename) {
     for (ParsingResult parsingResult : resultByFilename.values()) {
-      if (parsingResult.inputFile != null) {
+      if (parsingResult.inputFile != null && Groovy.KEY.equals(parsingResult.inputFile.language())) {
         for (Measure measure : parsingResult.builder.createMeasures()) {
           context.saveMeasure(parsingResult.inputFile, measure);
         }

--- a/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/cobertura/CoberturaSensorTest.java
+++ b/sonar-groovy-plugin/src/test/java/org/sonar/plugins/groovy/cobertura/CoberturaSensorTest.java
@@ -71,6 +71,8 @@ public class CoberturaSensorTest {
     when(mockfileSystem.predicates()).thenReturn(fileSystem.predicates());
     InputFile mockInputFile = mock(InputFile.class);
     when(mockInputFile.lines()).thenReturn(Integer.MAX_VALUE);
+    // The first class in the test coverage.xml is a java class and the rest are groovy
+    when(mockInputFile.language()).thenReturn("java", Groovy.KEY);
     when(mockfileSystem.inputFile(any(FilePredicate.class))).thenReturn(mockInputFile);
     sensor = new CoberturaSensor(settings, mockfileSystem);
     sensor.analyse(project, context);

--- a/sonar-groovy-plugin/src/test/resources/org/sonar/plugins/groovy/cobertura/coverage.xml
+++ b/sonar-groovy-plugin/src/test/resources/org/sonar/plugins/groovy/cobertura/coverage.xml
@@ -19,6 +19,24 @@
     <source></source>
   </sources>
   <packages>
+    <package name="com.test.web" line-rate="0.2222222222222222" branch-rate="1.0" complexity="1.0">
+      <classes>
+        <class name="com.test.web.EmptyResultException" filename="com/test/web/EmptyResultException.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+          <methods>
+            <method name="&lt;init&gt;" signature="(Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+              <lines>
+                <line number="16" hits="5" branch="false"/>
+                <line number="17" hits="5" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="16" hits="5" branch="false"/>
+            <line number="17" hits="5" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
     <package name="" line-rate="0.06451612903225806" branch-rate="0.0" complexity="0.0">
       <classes>
         <class name="AboveEighteenFilters" filename="AboveEighteenFilters.groovy" line-rate="1.0" branch-rate="1.0" complexity="0.0">


### PR DESCRIPTION
When a module has both java and groovy files, the cobertura report may have all of them. The groovy CoberturaReportParser adds measures of all those classes, including java. Later when CoberturaReportParser of java (sonar-cobertura plugin) tries to add the measures of the java files, it
fails with

```
[ERROR] Failed to execute goal org.codehaus.mojo:sonar-maven-plugin:2.7.1:sonar (default-cli) on
project test-parent: Can not add the same measure twice on org.sonar.api.resources.File@7c686152
```

See [my issue](https://stackoverflow.com/questions/37489010/sonar-groovy-plugin-adds-cobertura-measures-of-java-files) in stackoverflow